### PR TITLE
fix when context is document.documentElement

### DIFF
--- a/src/tools.js
+++ b/src/tools.js
@@ -26,7 +26,7 @@ export const calcEndPoint = (target, context = window, offset = 0) => {
     return parseInt(target) + offset
   }
   
-  const y = context === window
+  const y = (context === window || context === document.documentElement)
     ? window.pageYOffset 
     : context.scrollTop - context.getBoundingClientRect().top
     


### PR DESCRIPTION
When context is `document.documentElement`, `y` should be `window.pageYOffset` as well. 

See a failed case here: https://codesandbox.io/s/l96n04lk8l