### PR TITLE
Fixed context issue

### DIFF
--- a/src/scrollSmooth.js
+++ b/src/scrollSmooth.js
@@ -12,7 +12,7 @@ export default (
 ) => {
   if (typeof window !== 'object') return
 
-  const start = context.scrollTop || window.pageYOffset
+  const start = context.scrollTop ?? window.pageYOffset
   const end = calcEndPoint(target, context, offset)
   const clock = performance.now()
   const rAF = window.requestAnimationFrame


### PR DESCRIPTION
The context here can be a window, where scrollTop is undefined so this works perfectly. But when the context is HTMLElement and scrollTop is 0, this will incorrectly use window.pageYOffset instead of 0. The "??" should be used instead to make sure this works as expected. 